### PR TITLE
Fixed 'Cannot find module 'electron-compile' issue with built project

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Available commands:
 There are three different TypeScript configurations located in this repository, and all three of them are important:
 * [tsconfig.json](tsconfig.json) contains the configuration used by Visual Studio Code or other editors to configure TypeScript checking. This file pulls in additional type information from the [types](types/) directory, which contains a type definition necessary for proper code completion on imported Vue modules in Visual Studio Code.
 * [_compilerc](_compilerc) contains the two type definitions that are actually used when transpiling for use with Electron, one for development (used when running `npm start`) and one for production (used when running `npm run make`).
+* Due to a [known issue](https://github.com/electron-userland/electron-forge/issues/249) with `npm@4` and `@5`, it's advised to use `npm@3` with Electron Forge: ```npm install -g npm@3```
 
 ### Known issues/future work
 

--- a/package.json
+++ b/package.json
@@ -4,12 +4,14 @@
   "description": "",
   "main": "src/main.ts",
   "dependencies": {
+    "electron-compile": "^6.4.3",
+    "electron-squirrel-startup": "^1.0.0",
     "vue": "^2.4.4",
-    "vueify": "^9.4.1"
+    "vueify": "^9.4.1",
+    "electron-devtools-installer": "^2.2.0"
   },
   "devDependencies": {
     "@types/electron-devtools-installer": "^2.0.2",
-    "electron-devtools-installer": "^2.2.0",
     "electron-forge": "^4.0.2",
     "electron": "1.7.6",
     "electron-prebuilt-compile": "1.7.6",


### PR DESCRIPTION
I fixed the `Error: Cannot find module 'electron-compile'` described in #1.

- I noted that there is a [known issue](https://github.com/electron-userland/electron-forge/issues/249) with Electron Forge and `npm@4` and `npm@5`.  However, according to [this comment](https://github.com/electron-userland/electron-forge/issues/249#issuecomment-394911723) in the issue thread, this may not be totally necessary anymore.  Still, I think it's worth noting in the README.

- [I added](https://github.com/bdero/electron-vue-typescript-starter/compare/master...nigelgilbert:bugs/built-project-error?expand=1#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R7) `electron-compile` and `electron-squirrel-startup` to dependencies, since that is how the project generated by `electron-forge init` is configured:
<img width="450" alt="screen shot 2018-09-13 at 2 21 58 pm" src="https://user-images.githubusercontent.com/6457692/45510811-f29e3c80-b760-11e8-81bc-6af144a4d5f6.png">

- I [added](https://github.com/bdero/electron-vue-typescript-starter/compare/master...nigelgilbert:bugs/built-project-error?expand=1#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L12) `electron-devtools-installer` to dependencies, because I was getting this error:

<img width="450" alt="screen shot 2018-09-13 at 1 59 48 pm" src="https://user-images.githubusercontent.com/6457692/45510909-36914180-b761-11e8-9730-255df47429c7.png">


